### PR TITLE
Modernize codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Docs Status](https://docs.rs/thunk/badge.svg)](https://docs.rs/thunk)
 [![On crates.io](https://img.shields.io/crates/v/thunk.svg)](https://crates.io/crates/thunk)
 
-N.B. this crate requires nightly, as it makes use of `FnBox` and untagged unions.
+N.B. this crate requires nightly, as it makes use of `Box<FnOnce>`
+(`unsized_locals`) and `untagged_unions`.
 
 # `thunk`: Generic lazy evaluation for Rust
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!   over `AtomicThunk`.
 
 #![cfg_attr(test, feature(test))]
-#![feature(fnbox)]
+#![feature(unsized_locals)]
 #![feature(untagged_unions)]
 
 extern crate unreachable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@ pub mod sync;
 pub mod unsync;
 
 
-pub use strict::Strict;
-pub use sync::{AtomicThunk, ArcThunk};
-pub use unsync::{Thunk, RcThunk};
+pub use crate::strict::Strict;
+pub use crate::sync::{AtomicThunk, ArcThunk};
+pub use crate::unsync::{Thunk, RcThunk};
 
 
 /// The `Lazy` trait abstracts thunks which have exactly the same lifetimes
@@ -53,7 +53,7 @@ pub trait LazyRef
     /// Defer a computation stored as a `FnOnce` closure. Unwrapping/dereferencing
     /// will force the computation of the closure. The supplied closure must live
     /// as long as the type which the thunk computes.
-    fn defer<'a, F: FnOnce() -> Self::Target + 'a>(F) -> Self where Self::Target: 'a;
+    fn defer<'a, F: FnOnce() -> Self::Target + 'a>(closure: F) -> Self where Self::Target: 'a;
 
     /// Manually force a thunk's computation.
     fn force(&self);

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use ::{LazyRef, LazyMut, Lazy};
+use crate::{LazyRef, LazyMut, Lazy};
 
 
 /// A do-nothing, strict "thunk". This is intended for implementing structures which

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,4 @@
 use std::borrow::{Borrow, BorrowMut};
-use std::boxed::FnBox;
 use std::cell::UnsafeCell;
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -63,7 +62,7 @@ const THUNK_INVALIDATED: usize = 4;
 /// result.
 #[allow(unions_with_drop_fields)]
 union Cache<T> {
-    deferred: Box<dyn FnBox() -> ()>,
+    deferred: Box<dyn FnOnce() -> ()>,
     evaluated: T,
 
     #[allow(dead_code)]
@@ -95,7 +94,7 @@ impl<T> Cache<T> {
     unsafe fn evaluate_thunk(&mut self) {
         let Cache { deferred: thunk } = mem::replace(self, Cache { evaluating: () });
 
-        let thunk_cast = Box::from_raw(Box::into_raw(thunk) as *mut dyn FnBox() -> T);
+        let thunk_cast = Box::from_raw(Box::into_raw(thunk) as *mut dyn FnOnce() -> T);
 
         mem::replace(self, Cache { evaluated: thunk_cast() });
     }
@@ -212,12 +211,12 @@ impl<T> AtomicThunk<T> {
 
 impl<T> LazyRef for AtomicThunk<T> {
     #[inline]
-    fn defer<'a, F: FnBox() -> T + 'a>(f: F) -> AtomicThunk<T>
+    fn defer<'a, F: FnOnce() -> T + 'a>(f: F) -> AtomicThunk<T>
         where T: 'a
     {
         let thunk = unsafe {
-            let thunk_raw: *mut dyn FnBox() -> T = Box::into_raw(Box::new(f));
-            Box::from_raw(thunk_raw as *mut (dyn FnBox() -> () + 'static))
+            let thunk_raw: *mut dyn FnOnce() -> T = Box::into_raw(Box::new(f));
+            Box::from_raw(thunk_raw as *mut (dyn FnOnce() -> () + 'static))
         };
 
         AtomicThunk {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -172,9 +172,7 @@ impl<T> AtomicThunk<T> {
     #[inline]
     fn take_data(&mut self) -> Cache<T> {
         self.flag.store(THUNK_INVALIDATED, Ordering::Relaxed);
-        unsafe {
-            mem::replace(&mut self.data, UnsafeCell::new(Cache { evaluating: () })).into_inner()
-        }
+        mem::replace(&mut self.data, UnsafeCell::new(Cache { evaluating: () })).into_inner()
     }
 
 
@@ -257,15 +255,15 @@ impl<T> LazyRef for AtomicThunk<T> {
                 }
             }
 
-            /// If the `AtomicThunk` is evaluated, do nothing.
+            // If the `AtomicThunk` is evaluated, do nothing.
             THUNK_EVALUATED => {}
 
-            /// If the `AtomicThunk` is `LOCKING` or `LOCKED`, wait until the thunk is
-            /// done evaluating and then return a reference to the inner value.
+            // If the `AtomicThunk` is `LOCKING` or `LOCKED`, wait until the thunk is
+            // done evaluating and then return a reference to the inner value.
             THUNK_LOCKING | THUNK_LOCKED => unsafe { self.besiege() },
 
-            /// Only `THUNK_DEFERRED`, `THUNK_EVALUATED`, `THUNK_LOCKING`, and
-            /// `THUNK_LOCKED` are valid values of the flag.
+            // Only `THUNK_DEFERRED`, `THUNK_EVALUATED`, `THUNK_LOCKING`, and
+            // `THUNK_LOCKED` are valid values of the flag.
             THUNK_INVALIDATED |
             _ => unsafe { unreachable() },
         }

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -139,9 +139,7 @@ impl<T> Thunk<T> {
     #[inline]
     fn take_data(&mut self) -> Cache<T> {
         self.flag.set(Flag::Empty);
-        unsafe {
-            mem::replace(&mut self.data, UnsafeCell::new(Cache { evaluating: () })).into_inner()
-        }
+        mem::replace(&mut self.data, UnsafeCell::new(Cache { evaluating: () })).into_inner()
     }
 }
 


### PR DESCRIPTION
This fixes all current warnings, as well as those generated by `rust_2018_compatibility`, which contains problems that would prevent switching to the the 2018 edition, and those from `rust_2018_idioms`, which covers things which are now considered bad style. Additionally, it moves from using `FnBox` to using `FnOnce`, which requires a different feature flag, but appears to now be the preferred usage.

I'm happy to divide these up into separate pull requests if you like; I just didn't see the point as is.

